### PR TITLE
ERM-477: Added support for 2.0 and perms

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "parser": "babel-eslint",
+  "extends": "@folio/eslint-config-stripes"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-plugin-find-license
 
+## 3.4.0 IN PROGRESS
+* Fixed clear button in search box.
+* Added support for licenses interface 2.0
+* Added permission set
+
 ## 3.3.1 2019-09-06
 * Added translations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-license",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "License-finder for Stripes",
   "repository": "folio-org/ui-plugin-find-license",
   "publishConfig": {
@@ -13,7 +13,21 @@
   "stripes": {
     "type": "plugin",
     "pluginType": "find-license",
-    "displayName": "ui-plugin-find-license.meta.title"
+    "displayName": "ui-plugin-find-license.meta.title",
+    "okapiInterfaces": {
+      "licenses": "1.0 2.0"
+    },
+    "permissionSets": [
+      {
+        "permissionName": "ui-plugin-find-license.search",
+        "displayName": "Find License Plugin: Search licenses",
+        "visible": true,
+        "subPermissions": [
+          "licenses.licenses.view",
+          "licenses.orgs.view"
+        ]
+      }
+    ]
   },
   "scripts": {
     "lint": "eslint .",
@@ -28,8 +42,11 @@
     "react-dom": "^16.6.3"
   },
   "dependencies": {
+    "@folio/stripes-erm-components": "^1.4.0||^2.0.0",
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.0"
+    "lodash": "^4.17.11",
+    "prop-types": "^15.6.0",
+    "react-intl": "^2.4.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.0.0",

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -4,7 +4,6 @@ import { FormattedMessage } from 'react-intl';
 import { Modal } from '@folio/stripes/components';
 
 import Container from './Container';
-import packageInfo from '../package';
 import css from './LicenseSearch.css';
 
 export default class LicenseSearchModal extends React.Component {

--- a/src/View.js
+++ b/src/View.js
@@ -216,11 +216,7 @@ export default class View extends React.Component {
                                 marginBottom0
                                 name="query"
                                 onChange={getSearchHandlers().query}
-                                onClear={() => {
-                                  getSearchHandlers().clear();
-                                  // TODO: Add way to trigger search automatically
-                                  // onSubmitSearch();
-                                }}
+                                onClear={getSearchHandlers().reset}
                                 value={searchValue.query}
                               />
                             )}


### PR DESCRIPTION
- Registered the fact that we use the licenses okapi interface. Technically this is backwards-compatible with v1.0.
- Looped in a fix I found for the clearing of the text search field.
