### PR TITLE
Return focus to the lookup button when license lookup modal is closed…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ of the Module Developer's Guide.
 --- | --- | --- | --- |
 | `onLicenseSelected` | func: (license) => {} | Callback fired when a user clicks a license | Yes |
 | `dataKey` | string | Optional `dataKey` passed to stripes/connect when creating the connected Licenses component. |  |
-| `renderTrigger` | func: ({ triggerId, onClick }) => {} | Optional render function for the button to open the License search modal. The `onClick` prop should be called when the trigger is clicked (assuming it is a Button). | |
+| `renderTrigger` | func: ({ triggerId, onClick }) => {} | Optional render function for the button to open the License search modal. The `onClick` prop should be called when the trigger is clicked (assuming it is a Button). The `buttonRef` prop ensures that the trigger button is brought back into focus once the lookup modal is closed| |
 
 ## Additional information
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@folio/stripes-erm-components": "^1.4.0||^2.0.0",
     "classnames": "^2.2.5",
+    "dom-helpers": "^3.4.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0",
     "react-intl": "^2.4.0"

--- a/src/LicenseSearch.js
+++ b/src/LicenseSearch.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Icon } from '@folio/stripes/components';
+import contains from 'dom-helpers/query/contains';
 import Modal from './Modal';
 
 const triggerId = 'find-license-trigger';
@@ -9,16 +10,28 @@ class LicenseSearch extends React.Component {
     renderTrigger: PropTypes.func,
   };
 
-  state = {
-    open: false,
-  };
+  constructor(props) {
+    super(props);
+
+    this.modalRef = React.createRef();
+    this.modalTrigger = React.createRef();
+    this.state = {
+      open: false,
+    };
+  }
 
   openModal = () => {
     this.setState({ open: true });
   }
 
   closeModal = () => {
-    this.setState({ open: false });
+    this.setState({ open: false }, () => {
+      if (this.modalRef.current && this.modalTrigger.current) {
+        if (contains(this.modalRef.current, document.activeElement)) {
+          this.modalTrigger.current.focus();
+        }
+      }
+    });
   }
 
   renderDefaultTrigger() {
@@ -26,6 +39,7 @@ class LicenseSearch extends React.Component {
       <Button
         id={triggerId}
         buttonStyle="primary noRightRadius"
+        buttonRef={this.modalTrigger}
         onClick={this.openModal}
       >
         <Icon icon="search" color="#fff" />
@@ -42,6 +56,7 @@ class LicenseSearch extends React.Component {
       ? renderTrigger({
         id: triggerId,
         onClick: this.openModal,
+        buttonRef: this.modalTrigger,
       })
       : this.renderDefaultTrigger();
   }
@@ -51,6 +66,7 @@ class LicenseSearch extends React.Component {
       <React.Fragment>
         {this.renderTriggerButton()}
         <Modal
+          modalRef={this.modalRef}
           open={this.state.open}
           onClose={this.closeModal}
           {...this.props}

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -24,6 +24,7 @@ export default class LicenseSearchModal extends React.Component {
   constructor(props) {
     super(props);
 
+    this.modalRef = props.modalRef || React.createRef();
     this.connectedContainer = props.stripes.connect(Container, { dataKey: props.dataKey });
   }
 
@@ -44,6 +45,7 @@ export default class LicenseSearchModal extends React.Component {
             label={label}
             onClose={this.props.onClose}
             open={this.props.open}
+            ref={this.modalRef}
             size="large"
           >
             <this.connectedContainer

--- a/src/View.js
+++ b/src/View.js
@@ -78,8 +78,7 @@ export default class View extends React.Component {
     const { rowClass, rowData, rowIndex, rowProps = {}, cells } = row;
 
     return (
-      <div
-        aria-rowindex={rowIndex + 2}
+      <button
         className={rowClass}
         data-label={[
           rowData.name,
@@ -87,11 +86,11 @@ export default class View extends React.Component {
           this.formatter.status(rowData),
         ].join('...')}
         key={`row-${rowIndex}`}
-        role="row"
+        type="button"
         {...rowProps}
       >
         {cells}
-      </div>
+      </button>
     );
   }
 
@@ -205,7 +204,7 @@ export default class View extends React.Component {
                         {/* TODO: Use forthcoming <SearchGroup> or similar component */}
                         <div className={css.searchGroupWrap}>
                           <FormattedMessage id="ui-plugin-find-license.searchInputLabel">
-                            { ariaLabel => (
+                            {ariaLabel => (
                               <SearchField
                                 aria-label={ariaLabel}
                                 autoFocus


### PR DESCRIPTION
…, refs ERM-620, ERM-622

Should be merged after https://github.com/folio-org/stripes-components/pull/1115.

Focus on the button that triggers the modal on either closing a modal or selecting a row. 

Also, changed https://github.com/folio-org/ui-plugin-find-license/pull/56/files#diff-ce4229b24108600735f6e9fe9281461cR81 to a `button` so that the rows can be tabbed through (fixes ERM-622)