### PR TITLE
chore: Bumped to stripes-kint-components ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "typescript": "^2.8.0"
   },
   "dependencies": {
-    "@k-int/stripes-kint-components": "^3.0.3",
+    "@k-int/stripes-kint-components": "^4.0.0",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.4.0",
     "lodash": "^4.17.11",

--- a/src/Container.js
+++ b/src/Container.js
@@ -77,7 +77,7 @@ const Container = ({
     ['ERM', 'Licenses', licensesQueryParams, LICENSES_ENDPOINT],
     ({ pageParam = 0 }) => {
       const params = [...licensesQueryParams, `offset=${pageParam}`];
-      return ky.get(encodeURI(`${LICENSES_ENDPOINT}?${params?.join('&')}`)).json();
+      return ky.get(`${LICENSES_ENDPOINT}?${params?.join('&')}`).json();
     }
   );
 


### PR DESCRIPTION
kint-components 4.0.0 introduces a breaking change, encodeURI should no longer be performed on the output of generateKiwtQueryParams unless `encode` is set to false