### PR TITLE
[ERM-3129] Remove explicit typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "redux": "^4.0.0",
     "redux-observable": "^1.2.0",
     "regenerator-runtime": "^0.13.3",
-    "rxjs": "^6.6.3",
-    "typescript": "^2.8.0"
+    "rxjs": "^6.6.3"
   },
   "dependencies": {
     "@k-int/stripes-kint-components": "^5.1.1",


### PR DESCRIPTION
# [Jira ERM-3129](https://issues.folio.org/browse/ERM-3129)

As part of [Jira STRIPES-900](https://issues.folio.org/browse/STRIPES-900), all modules should use one `typescript` version, inherited from `@folio/stripes-webpack`.  Therefore, the explicit `typescript` version in this `package.json` should be removed.

