### PR TITLE
[FOLIO-4086] Fix GitHub Actions workflow not running for tags

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,4 +1,4 @@
-name: Centralized workflow test
+name: Centralized workflow
 on:
   - push
   - pull_request
@@ -8,6 +8,6 @@ jobs:
   ui:
     # Use the shared workflow from https://github.com/folio-org/.github
     uses: folio-org/.github/.github/workflows/ui.yml@v1
-    # Only handle push events from the main branch, to decrease noise
-    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
+    # Only handle push events from the main branch or tags, to decrease PR noise
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * ERM-3129 Remove explicit typescript version
 * Bumped folio dependencies
 * *BREAKING* Change interface dependency for licenses to just 6.0
+* FOLIO-4086 Fix GitHub Actions workflow not running for tags
 
 ## 10.0.0 2023-10-12
 * ERM-3033 *BREAKING* bump `react-intl` to `v6.4.4`


### PR DESCRIPTION
# [Jira FOLIO-4086](https://folio-org.atlassian.net/browse/FOLIO-4086)

Due to an error in the [recommended configuration for shared workflows](https://github.com/folio-org/.github/blob/master/README-UI.md), an incorrect conditional was added to the workflow which can cause GitHub Actions to not run on tags, making it impossible to release this module.

This PR resolves this by adjusting the condition to always run the workflow for pushes to tags.

Also, I removed the `test` in the workflow name as that was similarly left in the recommended configuration by accident, and has no reason to remain.